### PR TITLE
Add support for the arm64 architecture

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,7 +3,7 @@ before:
     - go mod tidy
     - go mod vendor
 builds:
-  - 
+  -
     id: commenter
     main: ./cmd/commenter
     binary: commenter
@@ -14,6 +14,7 @@ builds:
       - linux
     goarch:
       - amd64
+      - arm64
 
 snapshot:
   name_template: "{{ .Tag }}-next"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -32,9 +32,19 @@ function get_release_assets {
 }
 
 function install_release {
+  arch=""
+  case "$(uname -m)" in
+    "aarch64")
+      arch="arm64"
+      ;;
+    "x86_64")
+      arch="amd64"
+      ;;
+  esac
+
   repo="$1"
   version="$2"
-  binary="$3-linux-amd64"
+  binary="$3-linux-$arch"
   checksum="$4"
   release_assets="$(get_release_assets "${repo}" "${version}")"
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -2,3 +2,4 @@
 
 export GO111MODULE=auto
 GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o bin/commenter-linux-amd64 ./cmd/commenter
+GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -o bin/commenter-linux-arm64 ./cmd/commenter


### PR DESCRIPTION
It is for people trying to run an arm64-only infrastructure (for example, Gravitron). From my testing, we do not need any other changes.